### PR TITLE
Change scope shutdown to not call unsafeUnmask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Bugfix: Fix small memory leak related to closing a scope.
 - Bugfix: Fix subtle bug related to GHC's treatment of deadlocked threads.
 - Bugfix: make `async` propagate async exceptions.
+- Bugfix: make `scoped` honor `mask`
 
 - Performance: Use atomic fetch-and-add rather than a TVar to track internal child thread ids
 

--- a/src/Ki/Prelude.hs
+++ b/src/Ki/Prelude.hs
@@ -63,7 +63,7 @@ import Control.Monad as X (join, when)
 import Control.Monad.IO.Class as X (MonadIO (..))
 import Data.Coerce as X (coerce)
 import Data.Data as X (Data)
-import Data.Foldable as X (for_)
+import Data.Foldable as X (for_, traverse_)
 import Data.Function as X (fix)
 import Data.Functor as X (void, ($>), (<&>))
 import Data.Int as X


### PR DESCRIPTION
Modify how children propagate exceptions to parents and how parents shut down so that 'scoped' honors 'mask'