### PR TITLE
Fix parent

### DIFF
--- a/ki/CHANGELOG.md
+++ b/ki/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Bugfix: Fix subtle bug related to GHC's treatment of deadlocked threads.
 - Bugfix: make `async` (now `forktry`) propagate async exceptions.
 - Bugfix: make `scoped` safe to run with asynchronous exceptions masked.
+- Bugfix: propagate exceptions to creator of scope, not creator of thread
 
 - Performance: Use atomic fetch-and-add rather than a `TVar` to track internal child thread ids.
 


### PR DESCRIPTION
Previously, a child thread would propagate exceptions to the thread that created it, which is not necessarily its parent (which created its scope)