### PR TITLE
fix issue #19: deadlock

### DIFF
--- a/ki/CHANGELOG.md
+++ b/ki/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.0.2] - 2023-01-25
+
+- Bugfix [#20](https://github.com/awkward-squad/ki/pull/20): previously, a child thread could deadlock when attempting
+  to propagate an exception to its parent
+
 ## [1.0.0.1] - 2022-08-14
 
 - Compat: support GHC 9.4.1

--- a/ki/ki.cabal
+++ b/ki/ki.cabal
@@ -12,7 +12,7 @@ name: ki
 stability: experimental
 synopsis: A lightweight structured concurrency library
 -- tested-with: GHC == 9.0.2, GHC == 9.2.4, GHC == 9.4.1
-version: 1.0.0.1
+version: 1.0.0.2
 
 description:
   A lightweight structured concurrency library.


### PR DESCRIPTION
a deadlock could occur if a child, after beginning to tear down via a `ScopeClosing` exception delivered from its parent, ultimately wants to die with a different exception (e.g. a synchronous exception thrown during a registered cleanup action).

this PR makes a child thread that has an exception to propagate to its parent first check to see if its parent's scope is closed, and if it is, elects to communicate the exception via `childExceptionVar` rather than use `throwTo`