### PR TITLE
make `awaitAll` return () if scope is closed, rather than block forever

### DIFF
--- a/ki/CHANGELOG.md
+++ b/ki/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Change [#25](https://github.com/awkward-squad/ki/pull/20): Attempting to fork a thread in a closing scope now acts as
   if it were a child being terminated due to the scope closing. Previously, attempting to fork a thread in a closing
   scope would throw a runtime exception like `error "ki: scope closed"`.
+- Change [#27](https://github.com/awkward-squad/ki/pull/27): Calling `awaitAll` on a closed scope now returns `()`
+  instead of blocking forever.
 
 ## [1.0.0.2] - 2023-01-25
 


### PR DESCRIPTION
Fixes #26 